### PR TITLE
Fix: Only arm reload when existingCards exceeds 10 and not at exactly 10

### DIFF
--- a/frontend/src/components/Cards/Cards.jsx
+++ b/frontend/src/components/Cards/Cards.jsx
@@ -13,7 +13,7 @@ function Cards(props) {
 
   const datas = props.data;
   // console.log('data :',datas);
-  
+
 
   // for testing ..!
   // const datas = generateDummyData(41);
@@ -31,7 +31,7 @@ function Cards(props) {
   useEffect(() => {
     // If the length of existingCards is not 10,
     // set the armed flag so that when it returns to 10, we can reload.
-    if (existingCards.length !== 10) {
+    if (existingCards.length > 10) {
       armedRef.current = true;
     } else {
       // existingCards.length === 10


### PR DESCRIPTION
**Previous state** 

- When exactly 40 member => App crashing by loading the use useEffect. 
![before](https://github.com/user-attachments/assets/b17ccc62-d011-4112-b4ee-933797950ffe)

**Update** 
- When exactly 40 member

![after](https://github.com/user-attachments/assets/df75cca4-a452-4a82-8992-671d7a9fdd2d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the logic for triggering the refresh behavior in the card display, ensuring that updates occur only when the number of cards exceeds a specific threshold for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->