### PR TITLE
chore: reduce calendar display duration from 40s to 10s

### DIFF
--- a/src/utils/constants/displayConfig.js
+++ b/src/utils/constants/displayConfig.js
@@ -12,7 +12,7 @@ const DISPLAY_CONFIG = Object.freeze({
   MAKER_DURATION: 20_000,
 
   /** Duration (ms) the Calendar Dashboard is shown before rotating */
-  CALENDAR_DURATION: 40_000,
+  CALENDAR_DURATION: 10_000,
 
   /** Display views — used as state values by the orchestrator */
   VIEWS: Object.freeze({


### PR DESCRIPTION
reduce calendar display duration from 40s to 10s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the calendar dashboard display timing so it now refreshes sooner, improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->