### PR TITLE
Add local mock backend for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,40 @@ This project uses pnpm only. `npm install` and `yarn` are blocked.
 git clone https://github.com/tinkerhub/tinkerspace_digital.git
 cd tinkerspace_digital
 pnpm install
+pnpm dev:mock
+```
+
+The app runs at [http://localhost:3000](http://localhost:3000).
+
+### Local development without private backend access
+
+Use:
+
+```bash
+pnpm dev:mock
+```
+
+This starts:
+
+- the React dev server on `http://localhost:3000`
+- a local mock API server on `http://localhost:4010`
+
+The mock server exposes the same read endpoints the screen uses in production:
+
+- `GET /checkin/active`
+- `GET /api/v1/display`
+
+The seeded mock payloads include active makers, a live event, upcoming events, and a populated calendar so contributors can work on the UI without access to the internal TinkerHub services.
+
+### Local setup with private backend access
+
+If you have access to the real backend services:
+
+```bash
 cp .env.example .env
 # fill in the values in .env
 pnpm dev
 ```
-
-The app runs at [http://localhost:3000](http://localhost:3000).
 
 ### Environment variables
 
@@ -39,7 +67,10 @@ Copy `.env.example` to `.env` and set:
 | Command | Description |
 |---|---|
 | `pnpm dev` | Start the development server |
+| `pnpm dev:mock` | Start the development server with the built-in mock backend |
+| `pnpm mock:server` | Start only the local mock backend on port `4010` |
 | `pnpm build` | Create a production build |
+| `pnpm build:mock` | Create a production build configured against local mock API URLs |
 | `pnpm test` | Run tests |
 | `pnpm deploy` | Build and publish to GitHub Pages (legacy; production uses Netlify) |
 

--- a/mock-server/data.js
+++ b/mock-server/data.js
@@ -1,0 +1,213 @@
+const MOCK_MAKERS = [
+  {
+    membershipId: 'mk-001',
+    name: 'Harry Potter',
+    purpose: 'Working on a project',
+    workingOn: 'Marauder Map refresh',
+    avatar: '',
+  },
+  {
+    membershipId: 'mk-002',
+    name: 'Hermione Granger',
+    purpose: 'Self Learning',
+    workingOn: 'Advanced arithmancy notes',
+    avatar: '',
+  },
+  {
+    membershipId: 'mk-003',
+    name: 'Rubeus Hagrid',
+    purpose: 'On duty',
+    workingOn: 'Care of magical creatures desk',
+    avatar: '',
+  },
+  {
+    membershipId: 'mk-004',
+    name: 'Luna Lovegood',
+    purpose: 'Attending an event',
+    workingOn: 'Spectrespecs prototyping night',
+    avatar: '',
+  },
+  {
+    membershipId: 'mk-005',
+    name: 'Ron Weasley',
+    purpose: 'Working on a project',
+    projectName: 'Wizard chess scoreboard',
+    avatar: '',
+  },
+  {
+    membershipId: 'mk-006',
+    name: 'Ginny Weasley',
+    purpose: 'Visiting',
+    workingOn: 'Daily Prophet open house',
+    avatar: '',
+  },
+];
+
+function toIso(date) {
+  return date.toISOString();
+}
+
+function atTime(baseDate, dayOffset, hours, minutes = 0, durationMinutes = 60) {
+  const startsAt = new Date(baseDate);
+  startsAt.setDate(baseDate.getDate() + dayOffset);
+  startsAt.setHours(hours, minutes, 0, 0);
+
+  const endsAt = new Date(startsAt);
+  endsAt.setMinutes(endsAt.getMinutes() + durationMinutes);
+
+  return {
+    starts_at: toIso(startsAt),
+    ends_at: toIso(endsAt),
+  };
+}
+
+function startOfMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1, 9, 0, 0, 0);
+}
+
+function getMockMakers() {
+  return MOCK_MAKERS;
+}
+
+function getMockCalendarDisplay(now = new Date()) {
+  const monthAnchor = startOfMonth(now);
+
+  const liveStartsAt = new Date(now);
+  liveStartsAt.setMinutes(liveStartsAt.getMinutes() - 20, 0, 0);
+  const liveEndsAt = new Date(now);
+  liveEndsAt.setMinutes(liveEndsAt.getMinutes() + 70, 0, 0);
+
+  return {
+    live_event: {
+      id: 'live-dueling-club',
+      title: 'Dueling Club: Practical Defense Lab',
+      category: 'Talk',
+      status: 'ongoing',
+      starts_at: toIso(liveStartsAt),
+      ends_at: toIso(liveEndsAt),
+    },
+    upcoming_events: [
+      {
+        id: 'upcoming-marauders-workshop',
+        title: 'Marauders Workshop: Enchanted Map Interfaces',
+        category: 'Workshop',
+        status: 'upcoming',
+        ...atTime(now, 1, 18, 30, 90),
+      },
+      {
+        id: 'upcoming-common-room-open-house',
+        title: 'Common Room Open House for New Students',
+        category: 'Community',
+        status: 'upcoming',
+        ...atTime(now, 2, 16, 0, 120),
+      },
+      {
+        id: 'upcoming-potions-clinic',
+        title: 'Potions Clinic: Fine-Tuning Draught Ratios',
+        category: 'Research',
+        status: 'upcoming',
+        ...atTime(now, 4, 17, 0, 120),
+      },
+      {
+        id: 'upcoming-quidditch-night',
+        title: 'Quidditch Night: Build a Match Tracker',
+        category: 'Meetup',
+        status: 'upcoming',
+        ...atTime(now, 6, 18, 0, 150),
+      },
+      {
+        id: 'upcoming-charms-lab',
+        title: 'Charms Lab: Intro to Feather Levitation',
+        category: 'Learning Program',
+        status: 'upcoming',
+        ...atTime(now, 8, 11, 0, 120),
+      },
+      {
+        id: 'upcoming-great-hall-forum',
+        title: 'Great Hall Forum: What Should Hogwarts Build Next?',
+        category: 'Community',
+        status: 'upcoming',
+        ...atTime(now, 10, 19, 0, 90),
+      },
+    ],
+    calendar: [
+      {
+        id: 'calendar-01',
+        title: 'Defense Against the Dark Arts Studio',
+        category: 'Talk',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 2, 18, 0, 120),
+      },
+      {
+        id: 'calendar-02',
+        title: 'Forbidden Forest Field Workshop',
+        category: 'Workshop',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 3, 18, 30, 120),
+      },
+      {
+        id: 'calendar-03',
+        title: 'Order of the Phoenix Build Circle',
+        category: 'Meetup',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 5, 17, 30, 120),
+      },
+      {
+        id: 'calendar-04',
+        title: 'Hogsmeade Community Sync',
+        category: 'Community',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 8, 16, 0, 60),
+      },
+      {
+        id: 'calendar-05',
+        title: 'Rapid Broom Prototype Lab',
+        category: 'Workshop',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 10, 14, 0, 150),
+      },
+      {
+        id: 'calendar-06',
+        title: 'Great Hall Open House',
+        category: 'General Event',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 12, 11, 0, 180),
+      },
+      {
+        id: 'calendar-07',
+        title: 'Department of Mysteries Demo Review',
+        category: 'Research',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 15, 15, 0, 120),
+      },
+      {
+        id: 'calendar-08',
+        title: 'Triwizard Hack Night Warmup',
+        category: 'Hackathon',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 17, 18, 0, 180),
+      },
+      {
+        id: 'calendar-09',
+        title: 'O.W.L. Portfolio Clinic',
+        category: 'Learning Program',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 20, 17, 0, 90),
+      },
+      {
+        id: 'calendar-10',
+        title: 'Wizarding Community Film Night',
+        category: 'Community',
+        status: 'upcoming',
+        ...atTime(monthAnchor, 24, 19, 0, 120),
+      },
+    ],
+    generated_at: toIso(now),
+    api_version: 'mock-1',
+  };
+}
+
+module.exports = {
+  getMockMakers,
+  getMockCalendarDisplay,
+};

--- a/mock-server/server.js
+++ b/mock-server/server.js
@@ -1,0 +1,95 @@
+const http = require('http');
+const { URL } = require('url');
+const { getMockMakers, getMockCalendarDisplay } = require('./data');
+
+const PORT = Number(process.env.MOCK_SERVER_PORT || 4010);
+const API_KEY = process.env.MOCK_SPACECALENDAR_API_KEY || 'tinkerspace-local-dev';
+
+function writeJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, X-API-Key',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+function writeText(res, statusCode, text) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'text/plain; charset=utf-8',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, X-API-Key',
+    'Cache-Control': 'no-store',
+  });
+  res.end(text);
+}
+
+const server = http.createServer((req, res) => {
+  if (!req.url) {
+    writeText(res, 400, 'Missing request URL');
+    return;
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, X-API-Key',
+    });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'GET' && url.pathname === '/health') {
+    writeJson(res, 200, {
+      ok: true,
+      service: 'tinkerspace-digital-mock-server',
+      port: PORT,
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/checkin/active') {
+    writeJson(res, 200, getMockMakers());
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/v1/display') {
+    if (req.headers['x-api-key'] !== API_KEY) {
+      writeJson(res, 401, {
+        success: false,
+        error: 'Invalid X-API-Key for mock SpaceCalendar endpoint',
+      });
+      return;
+    }
+
+    writeJson(res, 200, {
+      success: true,
+      data: getMockCalendarDisplay(new Date()),
+    });
+    return;
+  }
+
+  writeJson(res, 404, {
+    success: false,
+    error: `No mock route for ${req.method} ${url.pathname}`,
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`[mock-server] listening on http://localhost:${PORT}`);
+  console.log('[mock-server] routes: GET /health, GET /checkin/active, GET /api/v1/display');
+});
+
+function shutdown(signal) {
+  console.log(`[mock-server] received ${signal}, shutting down`);
+  server.close(() => process.exit(0));
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "dev": "react-scripts start",
+    "dev:mock": "node scripts/dev-with-mocks.js",
+    "mock:server": "node mock-server/server.js",
     "build": "react-scripts build",
+    "build:mock": "node scripts/react-scripts-with-mocks.js build",
     "test": "react-scripts test",
     "deploy": "pnpm run build && gh-pages -d build"
   },

--- a/scripts/dev-with-mocks.js
+++ b/scripts/dev-with-mocks.js
@@ -1,0 +1,67 @@
+const { spawn } = require('child_process');
+
+const children = [];
+let shuttingDown = false;
+
+function startProcess(label, command, args, extraEnv = {}) {
+  const child = spawn(command, args, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  });
+
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    for (const proc of children) {
+      if (proc.pid && proc.pid !== child.pid) {
+        proc.kill('SIGTERM');
+      }
+    }
+
+    if (signal) {
+      console.error(`[${label}] exited with signal ${signal}`);
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 0);
+  });
+
+  children.push(child);
+  return child;
+}
+
+const mockPort = process.env.MOCK_SERVER_PORT || '4010';
+const mockApiKey = process.env.MOCK_SPACECALENDAR_API_KEY || 'tinkerspace-local-dev';
+
+startProcess('mock-server', 'node', ['mock-server/server.js'], {
+  MOCK_SERVER_PORT: mockPort,
+  MOCK_SPACECALENDAR_API_KEY: mockApiKey,
+});
+
+startProcess('frontend', 'node', ['scripts/react-scripts-with-mocks.js', 'start'], {
+  MOCK_SERVER_PORT: mockPort,
+  MOCK_SPACECALENDAR_API_KEY: mockApiKey,
+});
+
+function shutdown(signal) {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  for (const child of children) {
+    if (child.pid) {
+      child.kill('SIGTERM');
+    }
+  }
+  process.exit(0);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/scripts/react-scripts-with-mocks.js
+++ b/scripts/react-scripts-with-mocks.js
@@ -1,0 +1,28 @@
+const { spawn } = require('child_process');
+
+const command = process.argv[2] || 'start';
+const mockPort = process.env.MOCK_SERVER_PORT || '4010';
+const mockApiKey = process.env.MOCK_SPACECALENDAR_API_KEY || 'tinkerspace-local-dev';
+
+const child = spawn(
+  'pnpm',
+  ['exec', 'react-scripts', command],
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      REACT_APP_API_BASE_URL: process.env.REACT_APP_API_BASE_URL || `http://localhost:${mockPort}`,
+      REACT_APP_SPACECALENDAR_API: process.env.REACT_APP_SPACECALENDAR_API || `http://localhost:${mockPort}`,
+      REACT_APP_SPACECALENDAR_API_KEY:
+        process.env.REACT_APP_SPACECALENDAR_API_KEY || mockApiKey,
+    },
+  }
+);
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/src/utils/constants/badgeConfig.js
+++ b/src/utils/constants/badgeConfig.js
@@ -6,20 +6,20 @@ export const BADGE_TYPES = {
 
 export const USER_BADGES = {
   // Team Members
-  'Reema Shaji': [BADGE_TYPES.TEAM_MEMBER],
-  'Johnson Regi': [BADGE_TYPES.TEAM_MEMBER],
-  'Arundhathi Krishna': [BADGE_TYPES.TEAM_MEMBER],
+  'Harry Potter': [BADGE_TYPES.TEAM_MEMBER],
+  'Ron Weasley': [BADGE_TYPES.TEAM_MEMBER],
+  'Ginny Weasley': [BADGE_TYPES.TEAM_MEMBER],
   'Kurian Jacob': [BADGE_TYPES.TEAM_MEMBER],
   'Mehar M P': [BADGE_TYPES.TEAM_MEMBER],
   'Jasim C M': [BADGE_TYPES.TEAM_MEMBER],
   'User 1': [BADGE_TYPES.TEAM_MEMBER],
   
   // Project Contributors
-  'Imad Ibrahim': [BADGE_TYPES.PROJECT_CONTRIBUTOR],
-  'Affan Sajid': [BADGE_TYPES.PROJECT_CONTRIBUTOR],
+  'Hermione Granger': [BADGE_TYPES.PROJECT_CONTRIBUTOR],
+  'Luna Lovegood': [BADGE_TYPES.PROJECT_CONTRIBUTOR],
   
   // Guards
-  'Chandran P K': [BADGE_TYPES.GUARD],
+  'Rubeus Hagrid': [BADGE_TYPES.GUARD],
   'User 3': [BADGE_TYPES.GUARD]
 };
 


### PR DESCRIPTION
## What changed

- added a built-in local mock backend for the two private read APIs the display depends on
- added seeded fictional Harry Potter themed makers and event payloads for local development
- added `pnpm dev:mock`, `pnpm mock:server`, and `pnpm build:mock`
- documented the mock-backed local workflow in the README

## Why

The frontend was runnable, but contributors without access to the internal TinkerHub services could not meaningfully develop or verify the UI. This change preserves the existing production API contract while giving developers a self-contained local path.

## Developer impact

Contributors can now run the app locally with:

```bash
pnpm install
pnpm dev:mock
```

This starts the React app on `http://localhost:3000` and a local mock API on `http://localhost:4010`.

## Validation

- `pnpm dev:mock`
- `node scripts/react-scripts-with-mocks.js build`
