### PR TITLE
Harden mascot event policy

### DIFF
--- a/docs/tinkerspace-mascot-brief.md
+++ b/docs/tinkerspace-mascot-brief.md
@@ -20,9 +20,9 @@ The mascot is the existing hand-drawn maker avatar. Its personality is curious, 
 
 The mascot is not a page-change indicator. It is an ambient companion that occasionally does meaningful maker work.
 
-- On first appearance, the laptop sticker wakes: the mascot rolls its eyes and throws the TinkerHub label to its settled nearby position before entering the laptop-peek home state.
+- On first appearance, the laptop sticker wakes: the mascot rolls its eyes and throws the TinkerHub label to its settled nearby position before entering its configured home sequence. Events collected during awakening remain queued until that entry beat completes.
 - After two completed maker stories and at least one minute, it repeats the same return-to-sticker and label-throw beat. The shared sprite sheet owns the throw; the separate nearby wordmark appears only after that sheet has faded, then stays still. It never loops or circles around the mascot.
-- After a reset or sticker return, the mascot holds two or three irregular 35-90 second ambient turns before an autonomous maker story. Current home states are beanbag rest and laptop-peek; the sunglasses flourish is an occasional one-shot home beat rather than a loop.
+- After awakening, reset, or sticker return, the mascot holds two or three irregular 35-90 second ambient turns before an autonomous maker story. Current home states are beanbag rest and laptop-peek; the sunglasses flourish is an occasional one-shot home beat rather than a loop.
 - Ambient poses use small eye, blink, shoulder, and hand changes. The body should remain visually anchored so the character does not read as a sliding sticker.
 - Coding follows `debug` -> `breakthrough` -> `reset`.
 - Hardware follows `solder` -> `fix` -> `show` -> `reset`.
@@ -36,12 +36,14 @@ The mascot is not a page-change indicator. It is an ambient companion that occas
 The playback executor is event-aware without being event-driven in a robotic sense.
 
 - Page changes only influence the next autonomous work choice. They do not replace the active sprite.
-- Maker joins and weather changes enter a deduplicated priority queue and begin at a frame-cycle boundary.
+- Maker joins and weather changes enter a deduplicated semantic-event queue and begin at a frame-cycle boundary.
 - One-shot action sheets, including soldering, dance, and reset, play once and hold their final frame for a short randomized recovery pause before advancing. Queued events do not interrupt that recovery.
 - The sunglasses flourish uses the same one-shot policy, with a randomized 1.8-3.6 second recovery hold before returning to a normal home pose.
-- High-salience movement has a randomized 45-60 second attention cooldown. Weather reactions have a 15-minute cooldown.
+- High-salience community events have a randomized 45-60 second attention cooldown. Required story payoffs can finish their configured path and then start that cooldown. Weather reactions have a 15-minute cooldown.
 - Ambient selection is weighted rather than fixed. It favors the laptop-peek state, penalizes the three most recent poses, penalizes consecutive category repeats, and makes rest after recovery unlikely rather than impossible.
-- Weather and maker events wait for the current configured story or standalone path to finish, then enter through its recovery or home bridge.
+- Weather and maker events wait for the current configured story or standalone path to finish, then enter through its recovery or home bridge. A valid event blocked only by cooldown keeps the mascot in low-salience home behavior rather than allowing a new maker story to make that event stale.
+- Events use semantic identities, timestamps, expiry, and bounded priority aging. A newer event with the same dedupe key replaces its stale predecessor; an expired event is discarded.
+- Every pose uses one canonical scheduled-duration rule for normal entry and visibility resume.
 - Sprite changes crossfade for 380 ms at safe boundaries.
 
 This creates controlled variation: enough novelty to appear alive over a kiosk session, without the visual noise of random, unrelated pose changes.
@@ -74,8 +76,10 @@ Priority selector
   2. Continue the active causal maker story
   3. Play the highest-priority eligible queued event
   4. Return to sticker when its story-count and cooldown guards pass
-  5. Select a valid home beat
-  6. Select a valid new maker story
+  5. Enter the configured home sequence
+  6. Stay in home behavior while a valid event is cooldown-blocked
+  7. Continue the configured home sequence
+  8. Select a valid new maker story
 ```
 
 ### Context Blackboard
@@ -83,11 +87,11 @@ Priority selector
 The policy receives a compact immutable context for each decision:
 
 - `lastPose` and the current home-beat count.
-- `pendingEvents`, deduplicated by type and ordered by priority; app effects apply weather cooldowns before queueing.
+- `pendingEvents`, each with `type`, `reactionPose`, `dedupeKey`, `priority`, `createdAt`, `expiresAt`, and cooldown class.
 - Current display view as a soft bias; the calendar view increases the weight of the coding story and other views are neutral.
 - Recent poses, completed story domain, and completed story count.
 - A bounded session-exposure history that records the last twelve selected beats, so a pose or category that has dominated the session is gradually deprioritized without being permanently excluded.
-- Salient-motion and sticker-return cooldown deadlines.
+- Salient-motion, weather-reaction, and sticker-return cooldown deadlines.
 
 No policy branch reads browser state directly. App effects convert live maker, weather, and view changes into normalized context; the playback executor separately owns animation deadlines and visibility cleanup.
 
@@ -95,11 +99,11 @@ No policy branch reads browser state directly. App effects convert live maker, w
 
 The runtime separates visual assets from policy meaning:
 
-- The **asset manifest** is the single registry for sprite path, playback contract, visual category, energy level, standalone transitions, and complete maker-story definitions.
+- The **asset manifest** is the single registry for sprite path, playback contract, visual category, energy level, standalone transitions, complete maker-story definitions, and event definitions.
 - The **policy tree** evaluates priority, eligibility, and transitions using manifest IDs. It never references sprite file paths.
 - The **playback executor** resolves a selected manifest ID into the existing CSS/WebP sprite behavior.
 
-A manifest entry declares visual playback and story membership, but not global priority. For example, a prototype-testing pose can join the `hardware` story and inherit its causal sequencing. The policy decides whether a story, home beat, or queued event is eligible. This prevents individual assets from accumulating conflicting global rules.
+A manifest entry declares visual playback and story membership, but not global priority. For example, a prototype-testing pose can join the `hardware` story and inherit its causal sequencing. The policy decides whether a story, home beat, or queued event is eligible, and returns semantic effects such as `storyCompleted` rather than inferring completion from adjacent sprites. This prevents individual assets from accumulating conflicting global rules.
 
 ```js
 prototypeTest: {
@@ -114,8 +118,8 @@ To add a new animation, a developer should:
 
 1. Add the optimized WebP sprite under `public/images/mascot/dont-look/sprites/`.
 2. Register one manifest entry with the asset's visual and playback facts.
-3. Add the manifest ID to a `STORIES` path or the `homeBeat` selector. Weather reactions also require an explicit entry in the weather-pose mapping and event priority map.
-4. Add tests that prove the new candidate cannot bypass cooldown, story, or interruption rules.
+3. Add the manifest ID to a `STORIES` path or the `homeBeat` selector. Event reactions also require an explicit entry in `EVENT_DEFINITIONS` and the weather-pose mapping where applicable.
+4. Add tests that prove the new candidate cannot bypass cooldown, story, expiry, or interruption rules.
 
 The developer should not add timing logic, direct page checks, or global priority conditions to the asset definition.
 
@@ -131,8 +135,8 @@ The developer should not add timing logic, direct page checks, or global priorit
 
 | Signal | Policy effect | Safe release point |
 | --- | --- | --- |
-| Maker count increases | Queue one `dance` community event. | After the active maker story or recovery beat. |
-| Weather becomes rainy, hot, or cold | Queue the matching weather reaction if its cooldown has expired. | After the active maker story or recovery beat. |
+| Maker count increases | Queue one `maker-join` event with the `dance` reaction. | After the active maker story or recovery beat; expires if stale. |
+| Weather becomes rainy, hot, or cold | Queue or replace the current `weather` event with the matching reaction. | After the active maker story or recovery beat; policy enforces weather cooldown. |
 | Calendar or maker-feed context changes | Bias the next autonomous maker story. | Never interrupts the current pose. |
 | Two completed maker stories | Make a sticker-return sequence eligible. | After reset and its cooldown. |
 | No eligible event | Select a low-amplitude home beat or a new story. | At the next policy decision. |
@@ -142,7 +146,9 @@ The developer should not add timing logic, direct page checks, or global priorit
 - Coding remains `debug` -> `breakthrough` -> `reset`.
 - Hardware remains `solder` -> `fix` -> `show` -> `reset`.
 - A coding story and a hardware story never cut directly into one another; reset, weather, or a community beat bridges them.
-- High-salience poses obey the attention cooldown even when queued. Events remain pending instead of being discarded.
+- High-salience community events obey the attention cooldown. Required story payoffs are explicitly allowed to complete their causal path, then start the cooldown.
+- A cooldown-blocked event prevents a new maker story from beginning. The policy selects a low-salience home beat until the event plays or expires.
+- Expired or malformed events are removed before selection; unknown current pose IDs fall back safely to `ambientPeek`.
 - One-shot poses complete their frame cycle and recovery hold before a queued event is considered.
 - Home selection is weighted only after eligibility filtering. It excludes impossible candidates, strongly penalizes recent poses and category repeats, and makes recovery-to-rest uncommon rather than prohibited.
 - Session exposure applies a softer, longer-horizon penalty than recent-pose exclusion. It makes the policy explore compatible alternatives over time while retaining familiar low-salience home behavior.

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchData } from './utils/api/fetchData';
 import { removeDuplicates } from './utils/helpers/removeDuplicates';
+import { getMakerCardsPerPage } from './utils/layout/makerGrid';
 import DISPLAY_CONFIG from './utils/constants/displayConfig';
 import useDisplayOrchestrator from './hooks/useDisplayOrchestrator';
 import useGridLayout from './hooks/useGridLayout';
@@ -27,7 +28,7 @@ function App() {
 
     // Calculate layout here to determine totalPages for orchestrator
     const { cols, rows } = useGridLayout(CARD_WIDTH, CARD_HEIGHT, GAP);
-    const cardsPerPage = cols * rows;
+    const cardsPerPage = getMakerCardsPerPage(cols, rows);
     const totalPages = Math.ceil(data.length / cardsPerPage) || 1;
 
     // ── Display Orchestration Engine ─────────────────────────────

--- a/src/components/layout/PaginatedCardGrid.jsx
+++ b/src/components/layout/PaginatedCardGrid.jsx
@@ -9,7 +9,9 @@ const PAGE_INTERVAL = 20000;
 
 export default function PaginatedCardGrid({ data, isActive = true }) {
   const { cols, rows } = useGridLayout(CARD_WIDTH, CARD_HEIGHT, GAP);
-  const cardsPerPage = cols * rows;
+  const totalSlots = cols * rows;
+  // Keep the bottom-right grid cell clear for the fixed mascot overlay.
+  const cardsPerPage = Math.max(1, totalSlots - (totalSlots > 1 ? 1 : 0));
   const totalPages = Math.ceil(data.length / cardsPerPage) || 1;
   const [page, setPage] = useState(0);
   const intervalRef = useRef();
@@ -38,7 +40,7 @@ export default function PaginatedCardGrid({ data, isActive = true }) {
   const start = page * cardsPerPage;
   const end = start + cardsPerPage;
   const pageCards = data.slice(start, end);
-  const emptySlots = cardsPerPage - pageCards.length;
+  const emptySlots = totalSlots - pageCards.length;
 
   return (
     <div className="flex flex-col w-full h-full relative font-mono">

--- a/src/components/layout/PaginatedCardGrid.jsx
+++ b/src/components/layout/PaginatedCardGrid.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import CardItem from '../cards/UserCard';
 import useGridLayout from '../../hooks/useGridLayout';
+import { getMakerCardsPerPage } from '../../utils/layout/makerGrid';
 
 const CARD_WIDTH = 211;
 const CARD_HEIGHT = 257;
@@ -11,7 +12,7 @@ export default function PaginatedCardGrid({ data, isActive = true }) {
   const { cols, rows } = useGridLayout(CARD_WIDTH, CARD_HEIGHT, GAP);
   const totalSlots = cols * rows;
   // Keep the bottom-right grid cell clear for the fixed mascot overlay.
-  const cardsPerPage = Math.max(1, totalSlots - (totalSlots > 1 ? 1 : 0));
+  const cardsPerPage = getMakerCardsPerPage(cols, rows);
   const totalPages = Math.ceil(data.length / cardsPerPage) || 1;
   const [page, setPage] = useState(0);
   const intervalRef = useRef();

--- a/src/components/mascot/TinkerHubMascot.jsx
+++ b/src/components/mascot/TinkerHubMascot.jsx
@@ -1,18 +1,21 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { getCurrentWeather } from '../../utils/api/weatherService';
 import {
-  enqueuePose,
+  enqueueEvent,
   getPlayback,
-  getPoseDuration,
   getQueueDelay,
+  getScheduledPoseDuration,
 } from './playback';
-import { PLAYBACK_DURATIONS, POLICY_LIMITS, POSE_EVENT_PRIORITY, POSES } from './manifest';
-import { decideNextPose, getMakerDomain, getWeatherPose } from './policy';
+import {
+  EVENT_DEFINITIONS,
+  PLAYBACK_DURATIONS,
+  POLICY_LIMITS,
+  POSES,
+} from './manifest';
+import { decideNextPose, getWeatherPose } from './policy';
 
 const FADE_MS = 380;
 const PUBLIC_ASSET_BASE = process.env.PUBLIC_URL === '.' ? '' : process.env.PUBLIC_URL;
-const AWAKENING_DURATION_MS = POSES.awakening.cycle * getPlayback(POSES.awakening).cycles;
-const RETURNING_DURATION_MS = POSES.returning.cycle * getPlayback(POSES.returning).cycles;
 
 function randomDuration(min, max) {
   return min + Math.round(Math.random() * (max - min));
@@ -52,7 +55,7 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
     schedulerTimer.current = window.setTimeout(() => advanceRef.current?.(), delay);
   }, []);
 
-  const selectNextPose = useCallback(() => {
+  const selectNextPose = useCallback((preferHomeEntry = false) => {
     const decision = decideNextPose({
       now: Date.now(),
       pendingEvents: pendingPoses.current,
@@ -64,8 +67,10 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
       completedWorkStories: completedWorkStories.current,
       lastStickerReturnAt: lastStickerReturnAt.current,
       nextSalientAt: nextSalientAt.current,
+      lastWeatherReactionAt: lastWeatherReactionAt.current,
       homeTurns: homeTurns.current,
       homeTurnTarget: homeTurnTarget.current,
+      preferHomeEntry,
     });
 
     pendingPoses.current = decision.queue;
@@ -73,21 +78,26 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
       homeTurns.current = decision.home.turns;
       homeTurnTarget.current = decision.home.target;
     }
-    return decision.pose;
+    return decision;
   }, []);
 
-  const transitionTo = useCallback((nextPose) => {
+  const transitionTo = useCallback((decision) => {
+    const { pose: nextPose, effects } = decision;
     const currentPose = activePoseRef.current;
-    const currentDomain = getMakerDomain(currentPose);
 
     if (nextPose === 'returning') {
       window.clearTimeout(wordmarkTimer.current);
       setWordmarkVisible(false);
     }
 
-    if (nextPose === 'reset' && currentDomain !== 'neutral') {
-      lastCompletedWorkDomain.current = currentDomain;
+    if (effects?.storyCompleted) {
+      lastCompletedWorkDomain.current = effects.storyCompleted;
       completedWorkStories.current += 1;
+    }
+    if (effects?.eventPlayed?.type === 'weather') lastWeatherReactionAt.current = Date.now();
+    if (effects?.stickerReturned) {
+      lastStickerReturnAt.current = Date.now();
+      completedWorkStories.current = 0;
     }
 
     if (nextPose !== currentPose) {
@@ -111,24 +121,11 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
         POLICY_LIMITS.salientCooldown.max,
       );
     }
-    if (POSES[nextPose].kind === 'weather') lastWeatherReactionAt.current = Date.now();
     recentPoses.current = [...recentPoses.current, nextPose].slice(-POLICY_LIMITS.recentPoseLimit);
     sessionHistory.current = [...sessionHistory.current, nextPose]
       .slice(-POLICY_LIMITS.sessionExposureLimit);
-    if (nextPose === 'returning') {
-      lastStickerReturnAt.current = Date.now();
-      completedWorkStories.current = 0;
-      scheduleNext(RETURNING_DURATION_MS);
-      return;
-    }
-    if (POSES[nextPose].kind === 'ambient') {
-      scheduleNext(randomDuration(POLICY_LIMITS.homeHold.min, POLICY_LIMITS.homeHold.max));
-      return;
-    }
-
-    scheduleNext(getPoseDuration(
+    scheduleNext(getScheduledPoseDuration(
       POSES[nextPose],
-      isHighEnergy,
       PLAYBACK_DURATIONS,
       randomDuration,
     ));
@@ -138,11 +135,10 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
     advanceRef.current = () => transitionTo(selectNextPose());
   }, [selectNextPose, transitionTo]);
 
-  const queuePoseAtLoopBoundary = useCallback((pose) => {
-    pendingPoses.current = enqueuePose(
+  const queueEventAtLoopBoundary = useCallback((event) => {
+    pendingPoses.current = enqueueEvent(
       pendingPoses.current,
-      pose,
-      POSE_EVENT_PRIORITY[pose] || 0,
+      event,
     );
 
     // Let the intro and later return-to-sticker beat finish before outside events can interrupt them.
@@ -189,20 +185,31 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
     if (
       nextWeatherPose
       && nextWeatherPose !== weatherPoseRef.current
-      && Date.now() - lastWeatherReactionAt.current >= POLICY_LIMITS.weatherCooldown
     ) {
-      queuePoseAtLoopBoundary(nextWeatherPose);
+      const now = Date.now();
+      queueEventAtLoopBoundary({
+        ...EVENT_DEFINITIONS.weather,
+        reactionPose: nextWeatherPose,
+        createdAt: now,
+        expiresAt: now + EVENT_DEFINITIONS.weather.expiresAfter,
+      });
       weatherPoseRef.current = nextWeatherPose;
     }
     if (!nextWeatherPose) weatherPoseRef.current = null;
-  }, [weather, isVisible, queuePoseAtLoopBoundary]);
+  }, [weather, isVisible, queueEventAtLoopBoundary]);
 
   useEffect(() => {
     if (previousMakerCount.current !== null && makerCount > previousMakerCount.current) {
-      queuePoseAtLoopBoundary('dance');
+      const now = Date.now();
+      queueEventAtLoopBoundary({
+        ...EVENT_DEFINITIONS.makerJoin,
+        createdAt: now,
+        expiresAt: now + EVENT_DEFINITIONS.makerJoin.expiresAfter,
+        payload: { count: makerCount - previousMakerCount.current },
+      });
     }
     previousMakerCount.current = makerCount;
-  }, [makerCount, queuePoseAtLoopBoundary]);
+  }, [makerCount, queueEventAtLoopBoundary]);
 
   useEffect(() => {
     if (!isVisible) return undefined;
@@ -210,8 +217,8 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
     if (!hasAwakenedRef.current) {
       awakeningTimer.current = window.setTimeout(() => {
         hasAwakenedRef.current = true;
-        transitionTo('ambientPeek');
-      }, AWAKENING_DURATION_MS);
+        transitionTo(selectNextPose(true));
+      }, getScheduledPoseDuration(POSES.awakening, PLAYBACK_DURATIONS, randomDuration));
 
       return () => {
         window.clearTimeout(awakeningTimer.current);
@@ -225,26 +232,18 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
     const currentPose = activePoseRef.current;
     if (currentPose !== 'returning') setWordmarkVisible(true);
 
-    if (currentPose === 'returning') {
-      scheduleNext(RETURNING_DURATION_MS);
-    } else if (POSES[currentPose].kind === 'ambient') {
-      scheduleNext(randomDuration(PLAYBACK_DURATIONS.ambient.min, PLAYBACK_DURATIONS.ambient.max));
-    } else {
-      const isHighEnergy = POSES[currentPose].energy === 'high';
-      scheduleNext(getPoseDuration(
-        POSES[currentPose],
-        isHighEnergy,
-        PLAYBACK_DURATIONS,
-        randomDuration,
-      ));
-    }
+    scheduleNext(getScheduledPoseDuration(
+      POSES[currentPose],
+      PLAYBACK_DURATIONS,
+      randomDuration,
+    ));
     return () => {
       window.clearTimeout(schedulerTimer.current);
       window.clearTimeout(fadeTimer.current);
       window.clearTimeout(wordmarkTimer.current);
       setPreviousPose(null);
     };
-  }, [isVisible, scheduleNext, transitionTo]);
+  }, [isVisible, scheduleNext, selectNextPose, transitionTo]);
 
   if (!isVisible) return null;
 

--- a/src/components/mascot/TinkerHubMascot.jsx
+++ b/src/components/mascot/TinkerHubMascot.jsx
@@ -114,8 +114,9 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
       }
     }
 
-    const isHighEnergy = POSES[nextPose].energy === 'high';
-    if (isHighEnergy) {
+    const startsSalientCooldown = POSES[nextPose].salientRole === 'community-event'
+      || Boolean(effects?.storyCompleted);
+    if (startsSalientCooldown) {
       nextSalientAt.current = Date.now() + randomDuration(
         POLICY_LIMITS.salientCooldown.min,
         POLICY_LIMITS.salientCooldown.max,
@@ -195,7 +196,12 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
       });
       weatherPoseRef.current = nextWeatherPose;
     }
-    if (!nextWeatherPose) weatherPoseRef.current = null;
+    if (!nextWeatherPose) {
+      weatherPoseRef.current = null;
+      pendingPoses.current = pendingPoses.current.filter(
+        (event) => event.dedupeKey !== EVENT_DEFINITIONS.weather.dedupeKey,
+      );
+    }
   }, [weather, isVisible, queueEventAtLoopBoundary]);
 
   useEffect(() => {

--- a/src/components/mascot/manifest.js
+++ b/src/components/mascot/manifest.js
@@ -1,5 +1,5 @@
 export const POSES = {
-  awakening: { image: '/images/mascot/dont-look/sprites/awakening.webp', cycle: 1200, label: 'TinkerHub mascot coming alive from its sticker', playback: { cycles: 1 } },
+  awakening: { image: '/images/mascot/dont-look/sprites/awakening.webp', cycle: 1200, label: 'TinkerHub mascot coming alive from its sticker', playback: { cycles: 1 }, transition: 'home' },
   returning: { image: '/images/mascot/dont-look/sprites/awakening.webp', cycle: 1200, label: 'TinkerHub mascot returning to life from its sticker', playback: { cycles: 1 }, transition: 'home' },
   ambientGlance: { image: '/images/mascot/dont-look/sprites/ambient-glance.webp', cycle: 8000, label: 'TinkerHub mascot resting in a beanbag', category: 'rest', kind: 'ambient', weight: 1, avoidAfter: ['recovery'] },
   ambientPeek: { image: '/images/mascot/dont-look/sprites/ambient-peek.webp', cycle: 8000, label: 'TinkerHub mascot peeking over a laptop', category: 'focus', kind: 'ambient', weight: 2 },
@@ -17,7 +17,7 @@ export const POSES = {
   hot: { image: '/images/mascot/dont-look/sprites/hot.webp', cycle: 6000, label: 'TinkerHub maker managing the heat', kind: 'weather', transition: 'home' },
   winter: { image: '/images/mascot/dont-look/sprites/winter.webp', cycle: 6000, label: 'TinkerHub maker keeping warm', kind: 'weather', transition: 'home' },
   debug: { image: '/images/mascot/dont-look/sprites/debug.webp', cycle: 4200, label: 'TinkerHub maker debugging a bug', story: 'coding' },
-  breakthrough: { image: '/images/mascot/dont-look/sprites/breakthrough.webp', cycle: 900, label: 'TinkerHub maker celebrating a code breakthrough', story: 'coding', energy: 'high' },
+  breakthrough: { image: '/images/mascot/dont-look/sprites/breakthrough.webp', cycle: 900, label: 'TinkerHub maker celebrating a code breakthrough', story: 'coding', energy: 'high', salientRole: 'story-payoff' },
   solder: {
     image: '/images/mascot/dont-look/sprites/solder.webp',
     cycle: 4200,
@@ -33,6 +33,7 @@ export const POSES = {
     label: 'TinkerHub maker dancing in celebration',
     playback: { cycles: 1, hold: { min: 1400, max: 2800 } },
     energy: 'high',
+    salientRole: 'community-event',
     next: 'reset',
   },
   reset: {
@@ -73,11 +74,11 @@ export const POLICY_SELECTORS = {
 export const PLAYBACK_DURATIONS = {
   pulse: { min: 2100, max: 4200 },
   ambient: { min: 20000, max: 45000 },
+  home: { min: 35000, max: 90000 },
 };
 
 export const POLICY_LIMITS = {
   homeTurns: { min: 2, max: 3 },
-  homeHold: { min: 35000, max: 90000 },
   salientCooldown: { min: 45000, max: 60000 },
   weatherCooldown: 900000,
   stickerReturnCooldown: 60000,
@@ -86,9 +87,25 @@ export const POLICY_LIMITS = {
   sessionExposureLimit: 12,
 };
 
-export const POSE_EVENT_PRIORITY = {
-  rain: 2,
-  hot: 2,
-  winter: 2,
-  dance: 1,
+export const EVENT_DEFINITIONS = {
+  makerJoin: {
+    type: 'maker-join',
+    reactionPose: 'dance',
+    dedupeKey: 'maker-join',
+    priority: 1,
+    cooldown: 'salient',
+    expiresAfter: 120000,
+  },
+  weather: {
+    type: 'weather',
+    dedupeKey: 'weather',
+    priority: 2,
+    cooldown: 'weather',
+    expiresAfter: 1200000,
+  },
+};
+
+export const EVENT_POLICY = {
+  priorityAgingInterval: 60000,
+  priorityAgingCap: 2,
 };

--- a/src/components/mascot/playback.js
+++ b/src/components/mascot/playback.js
@@ -10,8 +10,8 @@ export function isOneShotPose(pose) {
   return Number.isFinite(getPlayback(pose).cycles);
 }
 
-/** Calculates the delay before the scheduler can advance a pose. */
-export function getPoseDuration(pose, isHighEnergy, durations, randomDuration) {
+/** Calculates the canonical delay before the policy can select another pose. */
+export function getScheduledPoseDuration(pose, durations, randomDuration) {
   const playback = getPlayback(pose);
   if (Number.isFinite(playback.cycles)) {
     const hold = playback.hold
@@ -20,28 +20,17 @@ export function getPoseDuration(pose, isHighEnergy, durations, randomDuration) {
     return pose.cycle * playback.cycles + hold;
   }
 
-  return isHighEnergy
+  return pose.kind === 'ambient'
+    ? randomDuration(durations.home.min, durations.home.max)
+    : pose.energy === 'high'
     ? randomDuration(durations.pulse.min, durations.pulse.max)
     : randomDuration(durations.ambient.min, durations.ambient.max);
 }
 
-/** Adds a pose once and orders queued events by descending priority. */
-export function enqueuePose(queue, pose, priority) {
-  if (queue.some((event) => event.pose === pose)) return queue;
-
-  return [...queue, { pose, priority }]
-    .sort((left, right) => right.priority - left.priority);
-}
-
-/** Removes and returns the first queued pose that is currently eligible. */
-export function takeEligiblePose(queue, isEligible) {
-  const index = queue.findIndex(({ pose }) => isEligible(pose));
-  if (index === -1) return { pose: null, queue };
-
-  return {
-    pose: queue[index].pose,
-    queue: [...queue.slice(0, index), ...queue.slice(index + 1)],
-  };
+/** Replaces stale events with the latest event for each semantic dedupe key. */
+export function enqueueEvent(queue, event) {
+  const withoutDuplicate = queue.filter((queued) => queued.dedupeKey !== event.dedupeKey);
+  return [...withoutDuplicate, event];
 }
 
 /** Waits for a one-shot to complete or a looping pose to reach its next boundary. */

--- a/src/components/mascot/playback.test.js
+++ b/src/components/mascot/playback.test.js
@@ -1,12 +1,17 @@
 import {
-  enqueuePose,
-  getPoseDuration,
+  enqueueEvent,
   getQueueDelay,
-  takeEligiblePose,
+  getScheduledPoseDuration,
 } from './playback';
 
 const loopingPose = { cycle: 1000 };
+const ambientPose = { cycle: 1000, kind: 'ambient' };
 const oneShotPose = { cycle: 1000, playback: { cycles: 1, hold: { min: 200, max: 400 } } };
+const durations = {
+  ambient: { min: 20000, max: 45000 },
+  home: { min: 35000, max: 90000 },
+  pulse: { min: 2100, max: 4200 },
+};
 
 describe('mascot playback helpers', () => {
   it('keeps a one-shot recovery hold intact for queued events', () => {
@@ -27,24 +32,17 @@ describe('mascot playback helpers', () => {
     })).toBe(350);
   });
 
-  it('deduplicates events and preserves priority', () => {
-    const queued = enqueuePose([], 'dance', 1);
-    const prioritised = enqueuePose(queued, 'rain', 2);
-    const deduplicated = enqueuePose(prioritised, 'dance', 1);
-
-    expect(deduplicated.map((event) => event.pose)).toEqual(['rain', 'dance']);
+  it('uses one duration definition for normal and resumed ambient playback', () => {
+    expect(getScheduledPoseDuration(ambientPose, durations, () => 42000)).toBe(42000);
+    expect(getScheduledPoseDuration(oneShotPose, durations, () => 300)).toBe(1300);
   });
 
-  it('keeps ineligible events queued until their cooldown ends', () => {
-    const queued = [{ pose: 'rain', priority: 2 }, { pose: 'dance', priority: 1 }];
-    const selection = takeEligiblePose(queued, (pose) => pose === 'rain');
+  it('deduplicates by semantic event key instead of reaction pose', () => {
+    const makerJoin = { type: 'maker-join', dedupeKey: 'maker-join', reactionPose: 'dance' };
+    const launchComplete = { type: 'launch-complete', dedupeKey: 'launch-complete', reactionPose: 'dance' };
+    const latestMakerJoin = { ...makerJoin, payload: { count: 3 } };
 
-    expect(selection.pose).toBe('rain');
-    expect(selection.queue).toEqual([{ pose: 'dance', priority: 1 }]);
+    const queue = enqueueEvent(enqueueEvent([], makerJoin), launchComplete);
+    expect(enqueueEvent(queue, latestMakerJoin)).toEqual([launchComplete, latestMakerJoin]);
   });
-
-  it('includes a randomized recovery hold in one-shot duration', () => {
-    expect(getPoseDuration(oneShotPose, false, {}, () => 300)).toBe(1300);
-  });
-
 });

--- a/src/components/mascot/policy.js
+++ b/src/components/mascot/policy.js
@@ -102,8 +102,10 @@ export function sanitizeEvents(events, now) {
     event
     && typeof event.type === 'string'
     && typeof event.dedupeKey === 'string'
-    && typeof event.createdAt === 'number'
-    && typeof event.expiresAt === 'number'
+    && Number.isFinite(event.createdAt)
+    && Number.isFinite(event.expiresAt)
+    && Number.isFinite(event.priority)
+    && typeof event.reactionPose === 'string'
     && event.expiresAt > now
     && POSES[event.reactionPose]
   ));
@@ -111,9 +113,10 @@ export function sanitizeEvents(events, now) {
 
 /** Computes priority with a bounded age bonus so older valid events are not starved. */
 export function getEffectiveEventPriority(event, now) {
+  const age = Math.max(0, now - event.createdAt);
   const ageBonus = Math.min(
     EVENT_POLICY.priorityAgingCap,
-    Math.floor((now - event.createdAt) / EVENT_POLICY.priorityAgingInterval),
+    Math.floor(age / EVENT_POLICY.priorityAgingInterval),
   );
   return event.priority + ageBonus;
 }

--- a/src/components/mascot/policy.js
+++ b/src/components/mascot/policy.js
@@ -1,5 +1,12 @@
-import { POLICY_LIMITS, POLICY_SELECTORS, POSES, STORIES } from './manifest';
-import { takeEligiblePose } from './playback';
+import {
+  EVENT_POLICY,
+  POLICY_LIMITS,
+  POLICY_SELECTORS,
+  POSES,
+  STORIES,
+} from './manifest';
+
+export const FALLBACK_POSE = 'ambientPeek';
 
 /** Converts a weather payload into the matching mascot reaction pose. */
 export function getWeatherPose(weather) {
@@ -7,11 +14,6 @@ export function getWeatherPose(weather) {
   if (weather?.temperature >= 32) return 'hot';
   if (weather?.temperature <= 24) return 'winter';
   return null;
-}
-
-/** Returns the maker domain represented by a pose, or neutral for bridges. */
-export function getMakerDomain(pose) {
-  return STORIES[POSES[pose]?.story]?.domain || 'neutral';
 }
 
 /** Returns the next configured step of a causal story, including recovery. */
@@ -61,7 +63,7 @@ export function choosePolicyPose(candidates, context, random = Math.random) {
   }
 
   return weightedCandidates.find((candidate) => candidate.weight > 0)?.pose
-    || weightedCandidates[weightedCandidates.length - 1].pose;
+    || FALLBACK_POSE;
 }
 
 /** Selects a configured maker story without repeating the completed domain. */
@@ -91,57 +93,171 @@ export function chooseMakerStory(context, random = Math.random) {
   }
 
   return weightedCandidates.find((candidate) => candidate.weight > 0)?.storyId
-    || weightedCandidates[weightedCandidates.length - 1].storyId;
+    || POLICY_SELECTORS.makerStories[0];
 }
 
-/** Runs the priority policy and returns a pose plus the remaining event queue. */
-export function decideNextPose(context, random = Math.random) {
-  const continuation = getPoseContinuation(context.lastPose);
-  if (continuation) {
-    return { pose: continuation, queue: context.pendingEvents, reason: 'continue-path' };
-  }
+/** Rejects malformed or expired events before they reach the decision tree. */
+export function sanitizeEvents(events, now) {
+  return events.filter((event) => (
+    event
+    && typeof event.type === 'string'
+    && typeof event.dedupeKey === 'string'
+    && typeof event.createdAt === 'number'
+    && typeof event.expiresAt === 'number'
+    && event.expiresAt > now
+    && POSES[event.reactionPose]
+  ));
+}
 
-  const queued = takeEligiblePose(
-    context.pendingEvents,
-    (pose) => POSES[pose].energy !== 'high' || context.now >= context.nextSalientAt,
+/** Computes priority with a bounded age bonus so older valid events are not starved. */
+export function getEffectiveEventPriority(event, now) {
+  const ageBonus = Math.min(
+    EVENT_POLICY.priorityAgingCap,
+    Math.floor((now - event.createdAt) / EVENT_POLICY.priorityAgingInterval),
   );
-  if (queued.pose) return { pose: queued.pose, queue: queued.queue, reason: 'queued-event' };
+  return event.priority + ageBonus;
+}
 
-  const current = POSES[context.lastPose];
+/** Keeps event cooldown eligibility inside the policy boundary. */
+export function isEventEligible(event, context) {
+  if (event.cooldown === 'salient') return context.now >= context.nextSalientAt;
+  if (event.cooldown === 'weather') {
+    return context.now - context.lastWeatherReactionAt >= POLICY_LIMITS.weatherCooldown;
+  }
+  return true;
+}
 
-  const canReturnToSticker = context.lastPose === 'reset'
+/** Returns the current valid event queue ordered by effective priority. */
+export function getQueuedEvents(context) {
+  return sanitizeEvents(context.pendingEvents, context.now)
+    .sort((left, right) => getEffectiveEventPriority(right, context.now) - getEffectiveEventPriority(left, context.now));
+}
+
+function homeDecision(context, random, reason, home) {
+  return {
+    pose: choosePolicyPose(POLICY_SELECTORS.homeBeat, context, random),
+    queue: getQueuedEvents(context),
+    reason,
+    home,
+  };
+}
+
+/** Branch 1: preserve a configured causal sequence and declare completion semantically. */
+export function continueActivePath(context) {
+  const continuation = getPoseContinuation(context.lastPose);
+  if (!continuation) return null;
+
+  const story = STORIES[POSES[context.lastPose]?.story];
+  const completesStory = story && continuation === story.recovery;
+  return {
+    pose: continuation,
+    queue: getQueuedEvents(context),
+    reason: 'continue-path',
+    effects: completesStory ? { storyCompleted: story.domain } : undefined,
+  };
+}
+
+/** Branch 2: release the highest-priority event whose policy cooldown has expired. */
+export function playEligibleQueuedEvent(context) {
+  if (context.preferHomeEntry) return null;
+
+  const queue = getQueuedEvents(context);
+  const event = queue.find((candidate) => isEventEligible(candidate, context));
+  if (!event) return null;
+
+  return {
+    pose: event.reactionPose,
+    queue: queue.filter((candidate) => candidate !== event),
+    reason: 'queued-event',
+    effects: { eventPlayed: event },
+  };
+}
+
+/** Branch 3: return to the sticker only after the configured story guard passes. */
+export function returnToSticker(context) {
+  const eligible = context.lastPose === 'reset'
     && context.completedWorkStories >= POLICY_LIMITS.storiesPerStickerReturn
     && context.now - context.lastStickerReturnAt >= POLICY_LIMITS.stickerReturnCooldown;
-  if (canReturnToSticker) return { pose: 'returning', queue: context.pendingEvents, reason: 'sticker-return' };
+  if (!eligible) return null;
 
-  if (current.transition === 'home') {
-    return {
-      pose: choosePolicyPose(POLICY_SELECTORS.homeBeat, context, random),
-      queue: context.pendingEvents,
-      reason: 'home-entry',
-      home: {
-        turns: 1,
-        target: random() < 0.5 ? POLICY_LIMITS.homeTurns.min : POLICY_LIMITS.homeTurns.max,
-      },
-    };
-  }
+  return {
+    pose: 'returning',
+    queue: getQueuedEvents(context),
+    reason: 'sticker-return',
+    effects: { stickerReturned: true },
+  };
+}
 
-  if (current.kind === 'ambient') {
-    if (context.homeTurns < context.homeTurnTarget) {
-      return {
-        pose: choosePolicyPose(POLICY_SELECTORS.homeBeat, context, random),
-        queue: context.pendingEvents,
-        reason: 'home-continue',
-        home: { turns: context.homeTurns + 1, target: context.homeTurnTarget },
-      };
-    }
-  }
+/** Branch 4: enter the configured home sequence after a home-transition pose. */
+export function enterHome(context, random) {
+  const current = POSES[context.lastPose];
+  if (current?.transition !== 'home') return null;
 
+  return homeDecision(context, random, 'home-entry', {
+    turns: 1,
+    target: random() < 0.5 ? POLICY_LIMITS.homeTurns.min : POLICY_LIMITS.homeTurns.max,
+  });
+}
+
+/** Branch 5: stay low-salience while a valid event is waiting for its cooldown. */
+export function waitForBlockedEvent(context, random) {
+  const hasBlockedEvent = getQueuedEvents(context).some((event) => !isEventEligible(event, context));
+  if (!hasBlockedEvent) return null;
+
+  return homeDecision(context, random, 'await-event', {
+    turns: Math.max(1, context.homeTurns),
+    target: Math.max(1, context.homeTurnTarget),
+  });
+}
+
+/** Branch 6: continue the configured home sequence. */
+export function continueHome(context, random) {
+  const current = POSES[context.lastPose];
+  if (current?.kind !== 'ambient' || context.homeTurns >= context.homeTurnTarget) return null;
+
+  return homeDecision(context, random, 'home-continue', {
+    turns: context.homeTurns + 1,
+    target: context.homeTurnTarget,
+  });
+}
+
+/** Branch 7: begin an eligible manifest-defined maker story. */
+export function startMakerStory(context, random) {
   const storyId = chooseMakerStory(context, random);
   return {
     pose: STORIES[storyId].steps[0],
-    queue: context.pendingEvents,
+    queue: getQueuedEvents(context),
     reason: 'new-maker-story',
     home: { turns: 0, target: 0 },
   };
+}
+
+export const POLICY_BRANCHES = [
+  continueActivePath,
+  playEligibleQueuedEvent,
+  returnToSticker,
+  enterHome,
+  waitForBlockedEvent,
+  continueHome,
+  startMakerStory,
+];
+
+/** Runs the event-bound priority policy and returns a pose plus semantic effects. */
+export function decideNextPose(context, random = Math.random) {
+  const queue = sanitizeEvents(context.pendingEvents, context.now);
+  if (!POSES[context.lastPose]) {
+    return { pose: FALLBACK_POSE, queue, reason: 'fallback' };
+  }
+
+  const safeContext = {
+    ...context,
+    pendingEvents: queue,
+  };
+
+  for (const branch of POLICY_BRANCHES) {
+    const decision = branch(safeContext, random);
+    if (decision) return decision;
+  }
+
+  return { pose: FALLBACK_POSE, queue: safeContext.pendingEvents, reason: 'fallback' };
 }

--- a/src/components/mascot/policy.js
+++ b/src/components/mascot/policy.js
@@ -106,6 +106,7 @@ export function sanitizeEvents(events, now) {
     && Number.isFinite(event.expiresAt)
     && Number.isFinite(event.priority)
     && typeof event.reactionPose === 'string'
+    && ['salient', 'weather'].includes(event.cooldown)
     && event.expiresAt > now
     && POSES[event.reactionPose]
   ));

--- a/src/components/mascot/policy.test.js
+++ b/src/components/mascot/policy.test.js
@@ -1,13 +1,13 @@
 import {
   chooseMakerStory,
-  decideNextPose,
   choosePolicyPose,
-  getPoseContinuation,
+  decideNextPose,
+  getEffectiveEventPriority,
   getWeatherPose,
 } from './policy';
 
 const baseContext = {
-  now: 100000,
+  now: 1000000,
   pendingEvents: [],
   lastPose: 'ambientPeek',
   recentPoses: [],
@@ -17,9 +17,23 @@ const baseContext = {
   completedWorkStories: 0,
   lastStickerReturnAt: 0,
   nextSalientAt: 0,
+  lastWeatherReactionAt: -1000000,
   homeTurns: 0,
   homeTurnTarget: 0,
 };
+
+function event(overrides) {
+  return {
+    type: 'maker-join',
+    dedupeKey: 'maker-join',
+    reactionPose: 'dance',
+    priority: 1,
+    cooldown: 'salient',
+    createdAt: baseContext.now,
+    expiresAt: baseContext.now + 120000,
+    ...overrides,
+  };
+}
 
 describe('mascot behaviour policy', () => {
   it('maps weather inputs to one meaningful reaction', () => {
@@ -28,83 +42,99 @@ describe('mascot behaviour policy', () => {
     expect(getWeatherPose({ temperature: 22 })).toBe('winter');
   });
 
-  it('continues a causal maker story before choosing another behavior', () => {
-    const decision = decideNextPose({ ...baseContext, lastPose: 'debug' });
-
-    expect(decision).toMatchObject({ pose: 'breakthrough', reason: 'continue-path' });
-  });
-
-  it('uses manifest transitions for standalone beats', () => {
-    expect(getPoseContinuation('dance')).toBe('reset');
-  });
-
-  it('defers a high-energy event until its cooldown ends', () => {
+  it('enters a configured two-or-three-turn home sequence after awakening', () => {
     const decision = decideNextPose({
       ...baseContext,
-      pendingEvents: [{ pose: 'dance', priority: 1 }],
-      nextSalientAt: baseContext.now + 1000,
-    });
+      lastPose: 'awakening',
+      preferHomeEntry: true,
+      pendingEvents: [event({ type: 'weather', dedupeKey: 'weather', reactionPose: 'rain', priority: 2 })],
+    }, () => 0);
 
-    expect(decision.pose).not.toBe('dance');
-    expect(decision.queue).toEqual([{ pose: 'dance', priority: 1 }]);
+    expect(decision.reason).toBe('home-entry');
+    expect(decision.home).toEqual({ turns: 1, target: 2 });
   });
 
-  it('finishes a configured story before releasing a queued event', () => {
-    const debugDecision = decideNextPose({
-      ...baseContext,
-      lastPose: 'debug',
-      pendingEvents: [{ pose: 'rain', priority: 2 }],
-    });
-    const breakthroughDecision = decideNextPose({
-      ...baseContext,
-      lastPose: 'breakthrough',
-      pendingEvents: [{ pose: 'rain', priority: 2 }],
-    });
-    const resetDecision = decideNextPose({
-      ...baseContext,
-      lastPose: 'reset',
-      pendingEvents: [{ pose: 'rain', priority: 2 }],
-    });
+  it('continues a causal story and declares completion as an effect', () => {
+    const debug = decideNextPose({ ...baseContext, lastPose: 'debug' });
+    const breakthrough = decideNextPose({ ...baseContext, lastPose: 'breakthrough' });
 
-    expect(debugDecision).toMatchObject({ pose: 'breakthrough', reason: 'continue-path' });
-    expect(breakthroughDecision).toMatchObject({ pose: 'reset', reason: 'continue-path' });
-    expect(resetDecision).toMatchObject({ pose: 'rain', reason: 'queued-event' });
+    expect(debug).toMatchObject({ pose: 'breakthrough', reason: 'continue-path' });
+    expect(breakthrough).toMatchObject({
+      pose: 'reset',
+      effects: { storyCompleted: 'coder' },
+    });
   });
 
-  it('returns to the sticker after the configured number of completed stories', () => {
+  it('holds a blocked celebration in low-salience home behavior', () => {
     const decision = decideNextPose({
       ...baseContext,
-      lastPose: 'reset',
-      completedWorkStories: 2,
-    });
-
-    expect(decision).toMatchObject({ pose: 'returning', reason: 'sticker-return' });
-  });
-
-  it('alternates a new maker story after hardware work', () => {
-    const decision = decideNextPose({
-      ...baseContext,
-      lastPose: 'ambientPeek',
+      pendingEvents: [event()],
+      nextSalientAt: baseContext.now + 5000,
       homeTurns: 2,
       homeTurnTarget: 2,
-      lastCompletedWorkDomain: 'hardware',
     });
 
-    expect(decision).toMatchObject({ pose: 'debug', reason: 'new-maker-story' });
+    expect(decision).toMatchObject({ reason: 'await-event' });
+    expect(decision.pose).not.toBe('debug');
+    expect(decision.queue).toEqual([event()]);
   });
 
-  it('discovers alternate maker stories from the manifest', () => {
+  it('applies weather cooldown inside the policy', () => {
+    const weatherEvent = event({
+      type: 'weather',
+      dedupeKey: 'weather',
+      reactionPose: 'rain',
+      priority: 2,
+      cooldown: 'weather',
+    });
+    const blocked = decideNextPose({
+      ...baseContext,
+      pendingEvents: [weatherEvent],
+      lastWeatherReactionAt: baseContext.now - 1000,
+      homeTurns: 2,
+      homeTurnTarget: 2,
+    });
+    const eligible = decideNextPose({
+      ...baseContext,
+      pendingEvents: [weatherEvent],
+      homeTurns: 2,
+      homeTurnTarget: 2,
+    });
+
+    expect(blocked.reason).toBe('await-event');
+    expect(eligible).toMatchObject({ pose: 'rain', reason: 'queued-event' });
+  });
+
+  it('ages valid events and discards expired or unknown reactions', () => {
+    const older = event({ createdAt: baseContext.now - 120000 });
+    const stale = event({ dedupeKey: 'stale', expiresAt: baseContext.now - 1 });
+    const malformed = event({ dedupeKey: 'bad', reactionPose: 'missing-pose' });
+    const decision = decideNextPose({
+      ...baseContext,
+      pendingEvents: [stale, malformed, older],
+    });
+
+    expect(getEffectiveEventPriority(older, baseContext.now)).toBe(3);
+    expect(decision).toMatchObject({ pose: 'dance', reason: 'queued-event' });
+    expect(decision.queue).toEqual([]);
+  });
+
+  it('uses a safe fallback when the current pose is invalid', () => {
+    const decision = decideNextPose({ ...baseContext, lastPose: 'invalid-pose' }, () => 0);
+
+    expect(decision).toMatchObject({ pose: 'ambientPeek', reason: 'fallback' });
+  });
+
+  it('alternates new maker stories and reduces repeated session exposure', () => {
     expect(chooseMakerStory({ ...baseContext, lastCompletedWorkDomain: 'hardware' }, () => 0))
       .toBe('coding');
-  });
 
-  it('reduces a pose weight after repeated session exposure', () => {
     const context = {
       ...baseContext,
       lastPose: 'reset',
       sessionHistory: ['ambientPeek', 'ambientPeek', 'ambientPeek', 'ambientPeek'],
     };
-
-    expect(choosePolicyPose(['ambientPeek', 'ambientGlance'], context, () => 0.9)).toBe('ambientGlance');
+    expect(choosePolicyPose(['ambientPeek', 'ambientGlance'], context, () => 0.9))
+      .toBe('ambientGlance');
   });
 });

--- a/src/components/mascot/policy.test.js
+++ b/src/components/mascot/policy.test.js
@@ -105,18 +105,26 @@ describe('mascot behaviour policy', () => {
     expect(eligible).toMatchObject({ pose: 'rain', reason: 'queued-event' });
   });
 
-  it('ages valid events and discards expired or unknown reactions', () => {
+  it('ages valid events and discards malformed or expired events', () => {
     const older = event({ createdAt: baseContext.now - 120000 });
     const stale = event({ dedupeKey: 'stale', expiresAt: baseContext.now - 1 });
     const malformed = event({ dedupeKey: 'bad', reactionPose: 'missing-pose' });
+    const invalidTiming = event({ dedupeKey: 'invalid-timing', createdAt: Number.NaN });
+    const invalidPriority = event({ dedupeKey: 'invalid-priority', priority: Number.POSITIVE_INFINITY });
     const decision = decideNextPose({
       ...baseContext,
-      pendingEvents: [stale, malformed, older],
+      pendingEvents: [stale, malformed, invalidTiming, invalidPriority, older],
     });
 
     expect(getEffectiveEventPriority(older, baseContext.now)).toBe(3);
     expect(decision).toMatchObject({ pose: 'dance', reason: 'queued-event' });
     expect(decision.queue).toEqual([]);
+  });
+
+  it('does not reduce event priority when its timestamp is in the future', () => {
+    const futureEvent = event({ createdAt: baseContext.now + 120000 });
+
+    expect(getEffectiveEventPriority(futureEvent, baseContext.now)).toBe(futureEvent.priority);
   });
 
   it('uses a safe fallback when the current pose is invalid', () => {

--- a/src/components/mascot/policy.test.js
+++ b/src/components/mascot/policy.test.js
@@ -111,9 +111,10 @@ describe('mascot behaviour policy', () => {
     const malformed = event({ dedupeKey: 'bad', reactionPose: 'missing-pose' });
     const invalidTiming = event({ dedupeKey: 'invalid-timing', createdAt: Number.NaN });
     const invalidPriority = event({ dedupeKey: 'invalid-priority', priority: Number.POSITIVE_INFINITY });
+    const invalidCooldown = event({ dedupeKey: 'invalid-cooldown', cooldown: 'unknown' });
     const decision = decideNextPose({
       ...baseContext,
-      pendingEvents: [stale, malformed, invalidTiming, invalidPriority, older],
+      pendingEvents: [stale, malformed, invalidTiming, invalidPriority, invalidCooldown, older],
     });
 
     expect(getEffectiveEventPriority(older, baseContext.now)).toBe(3);

--- a/src/utils/layout/makerGrid.js
+++ b/src/utils/layout/makerGrid.js
@@ -1,0 +1,5 @@
+/** Returns the maker cards that fit while reserving the bottom-right mascot slot. */
+export function getMakerCardsPerPage(cols, rows) {
+  const totalSlots = cols * rows;
+  return Math.max(1, totalSlots - (totalSlots > 1 ? 1 : 0));
+}

--- a/src/utils/layout/makerGrid.test.js
+++ b/src/utils/layout/makerGrid.test.js
@@ -1,0 +1,8 @@
+import { getMakerCardsPerPage } from './makerGrid';
+
+describe('getMakerCardsPerPage', () => {
+  it('reserves the bottom-right slot while retaining a one-slot layout', () => {
+    expect(getMakerCardsPerPage(3, 2)).toBe(5);
+    expect(getMakerCardsPerPage(1, 1)).toBe(1);
+  });
+});


### PR DESCRIPTION
Hardens the mascot behavior policy around real events and safe playback.

- Replace pose queue entries with structured semantic events, expiry, dedupe keys, and bounded aging.
- Move weather and salient-event eligibility into pure policy branches.
- Add explicit semantic effects and canonical duration scheduling.
- Guarantee home entry after awakening and prevent cooldown-blocked celebrations from being delayed behind a new story.
- Update policy tests and the mascot ground-truth brief.

Validation:
- `CI=true pnpm test --watchAll=false --runInBand src/components/mascot/policy.test.js src/components/mascot/playback.test.js`
- `pnpm run build`
- Local browser verification`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mascot animations with smoother awakening, home-entry, ambient, weather, maker, and recovery sequences.
  * Mascot events now play in a more consistent order, avoid unnecessary repetition, and respect cooldowns and expiration.
  * Added safer fallback behavior for unexpected mascot states.
* **Bug Fixes**
  * Updated card-grid pagination to reserve the bottom-right cell consistently and fill remaining spaces correctly.
* **Documentation**
  * Refined the mascot behavior and playback guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->