### PR TITLE
Harden mascot animation fallback

### DIFF
--- a/src/components/mascot/TinkerHubMascot.jsx
+++ b/src/components/mascot/TinkerHubMascot.jsx
@@ -58,10 +58,13 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
   const wordmarkTimer = useRef(null);
   const awakeningTimer = useRef(null);
   const watchdogTimer = useRef(null);
+  const failSafeActiveRef = useRef(false);
   const hasAwakenedRef = useRef(false);
   const advanceRef = useRef(null);
 
   const activateFailSafe = useCallback((reason) => {
+    if (failSafeActiveRef.current) return;
+    failSafeActiveRef.current = true;
     window.clearTimeout(schedulerTimer.current);
     window.clearTimeout(fadeTimer.current);
     window.clearTimeout(wordmarkTimer.current);
@@ -73,6 +76,7 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
   }, []);
 
   const scheduleNext = useCallback((delay, trackPoseDeadline = true) => {
+    if (failSafeActiveRef.current) return;
     window.clearTimeout(schedulerTimer.current);
     if (trackPoseDeadline) poseEndsAt.current = Date.now() + delay;
     schedulerTimer.current = window.setTimeout(() => advanceRef.current?.(), delay);
@@ -161,6 +165,7 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
   }, [selectNextPose, transitionTo]);
 
   const queueEventAtLoopBoundary = useCallback((event) => {
+    if (failSafeActiveRef.current) return;
     pendingPoses.current = enqueueEvent(
       pendingPoses.current,
       event,

--- a/src/components/mascot/TinkerHubMascot.jsx
+++ b/src/components/mascot/TinkerHubMascot.jsx
@@ -13,9 +13,18 @@ import {
   POSES,
 } from './manifest';
 import { decideNextPose, getWeatherPose } from './policy';
+import {
+  getMascotAssetUrl,
+  getMascotWatchdogFailure,
+} from './watchdog';
 
 const FADE_MS = 380;
+const WATCHDOG_INTERVAL_MS = 5000;
+const WATCHDOG_SCHEDULER_GRACE_MS = 12000;
+const WATCHDOG_ANIMATION_GRACE_MS = 15000;
+const MASCOT_ASSET_VERSION = process.env.REACT_APP_MASCOT_ASSET_VERSION || 'mascot-watchdog-v1';
 const PUBLIC_ASSET_BASE = process.env.PUBLIC_URL === '.' ? '' : process.env.PUBLIC_URL;
+const FALLBACK_STICKER_IMAGE = '/images/dont-look.png';
 
 function randomDuration(min, max) {
   return min + Math.round(Math.random() * (max - min));
@@ -26,9 +35,11 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
   const [activePose, setActivePose] = useState('awakening');
   const [previousPose, setPreviousPose] = useState(null);
   const [wordmarkVisible, setWordmarkVisible] = useState(false);
+  const [failSafeReason, setFailSafeReason] = useState(null);
   const activePoseRef = useRef('awakening');
   const poseStartedAt = useRef(Date.now());
   const poseEndsAt = useRef(0);
+  const lastAnimationHeartbeatAt = useRef(Date.now());
   const previousMakerCount = useRef(null);
   const weatherPoseRef = useRef(null);
   const pendingPoses = useRef([]);
@@ -46,8 +57,20 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
   const fadeTimer = useRef(null);
   const wordmarkTimer = useRef(null);
   const awakeningTimer = useRef(null);
+  const watchdogTimer = useRef(null);
   const hasAwakenedRef = useRef(false);
   const advanceRef = useRef(null);
+
+  const activateFailSafe = useCallback((reason) => {
+    window.clearTimeout(schedulerTimer.current);
+    window.clearTimeout(fadeTimer.current);
+    window.clearTimeout(wordmarkTimer.current);
+    window.clearTimeout(awakeningTimer.current);
+    window.clearInterval(watchdogTimer.current);
+    setPreviousPose(null);
+    setWordmarkVisible(false);
+    setFailSafeReason(reason);
+  }, []);
 
   const scheduleNext = useCallback((delay, trackPoseDeadline = true) => {
     window.clearTimeout(schedulerTimer.current);
@@ -106,6 +129,7 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
       setActivePose(nextPose);
       activePoseRef.current = nextPose;
       poseStartedAt.current = Date.now();
+      lastAnimationHeartbeatAt.current = Date.now();
       fadeTimer.current = window.setTimeout(() => setPreviousPose(null), FADE_MS);
 
       if (currentPose === 'awakening' || currentPose === 'returning') {
@@ -247,14 +271,80 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
       window.clearTimeout(schedulerTimer.current);
       window.clearTimeout(fadeTimer.current);
       window.clearTimeout(wordmarkTimer.current);
+      window.clearInterval(watchdogTimer.current);
       setPreviousPose(null);
     };
   }, [isVisible, scheduleNext, selectNextPose, transitionTo]);
 
+  useEffect(() => {
+    if (!isVisible || failSafeReason) return undefined;
+
+    let cancelled = false;
+    const image = new Image();
+    image.onload = () => {
+      cancelled = true;
+    };
+    image.onerror = () => {
+      if (!cancelled) activateFailSafe('asset-error');
+    };
+    image.src = getMascotAssetUrl(PUBLIC_ASSET_BASE, POSES[activePose].image, MASCOT_ASSET_VERSION);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activePose, activateFailSafe, failSafeReason, isVisible]);
+
+  useEffect(() => {
+    if (!isVisible || failSafeReason) return undefined;
+
+    watchdogTimer.current = window.setInterval(() => {
+      if (document.hidden) {
+        lastAnimationHeartbeatAt.current = Date.now();
+        return;
+      }
+
+      const reason = getMascotWatchdogFailure({
+        now: Date.now(),
+        pose: POSES[activePoseRef.current],
+        poseEndsAt: poseEndsAt.current,
+        lastAnimationHeartbeatAt: lastAnimationHeartbeatAt.current,
+        hasAwakened: hasAwakenedRef.current,
+        schedulerGraceMs: WATCHDOG_SCHEDULER_GRACE_MS,
+        animationGraceMs: WATCHDOG_ANIMATION_GRACE_MS,
+      });
+
+      if (reason) activateFailSafe(reason);
+    }, WATCHDOG_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(watchdogTimer.current);
+    };
+  }, [activateFailSafe, failSafeReason, isVisible]);
+
   if (!isVisible) return null;
+
+  if (failSafeReason) {
+    return (
+      <div
+        className="tinkerhub-mascot tinkerhub-mascot--fallback"
+        data-failsafe-reason={failSafeReason}
+      >
+        <img
+          className="tinkerhub-mascot__fallback-sticker"
+          src={getMascotAssetUrl(PUBLIC_ASSET_BASE, FALLBACK_STICKER_IMAGE, MASCOT_ASSET_VERSION)}
+          alt="TinkerHub mascot sticker"
+        />
+      </div>
+    );
+  }
 
   const renderSprite = (pose, className) => {
     const playback = getPlayback(POSES[pose]);
+    const markAnimationHeartbeat = (event) => {
+      if (event.animationName === 'mascot-sprite') {
+        lastAnimationHeartbeatAt.current = Date.now();
+      }
+    };
 
     return (
       <div
@@ -262,8 +352,10 @@ export default function TinkerHubMascot({ makerCount, currentView, isVisible }) 
         className={`tinkerhub-mascot__sprite ${className}`}
         role={className === 'tinkerhub-mascot__sprite--active' ? 'img' : undefined}
         aria-label={className === 'tinkerhub-mascot__sprite--active' ? POSES[pose].label : undefined}
+        onAnimationStart={markAnimationHeartbeat}
+        onAnimationIteration={markAnimationHeartbeat}
         style={{
-          '--mascot-sprite': `url(${PUBLIC_ASSET_BASE}${POSES[pose].image})`,
+          '--mascot-sprite': `url(${getMascotAssetUrl(PUBLIC_ASSET_BASE, POSES[pose].image, MASCOT_ASSET_VERSION)})`,
           '--mascot-cycle': `${POSES[pose].cycle}ms`,
           '--mascot-sprite-iterations': Number.isFinite(playback.cycles) ? playback.cycles : 'infinite',
         }}

--- a/src/components/mascot/TinkerHubMascot.test.jsx
+++ b/src/components/mascot/TinkerHubMascot.test.jsx
@@ -1,0 +1,78 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import TinkerHubMascot from './TinkerHubMascot';
+
+jest.mock('../../utils/api/weatherService', () => ({
+  getCurrentWeather: jest.fn(() => Promise.resolve(null)),
+}));
+
+describe('TinkerHubMascot fail-safe lifecycle', () => {
+  let container;
+  let root;
+  let originalImage;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    jest.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    originalImage = global.Image;
+
+    global.Image = class {
+      set src(_value) {
+        setTimeout(() => this.onerror?.(), 0);
+      }
+    };
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+    global.Image = originalImage;
+    jest.useRealTimers();
+    delete global.IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('does not resume mascot scheduling after fail-safe activation', async () => {
+    const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+
+    await act(async () => {
+      root.render(
+        <TinkerHubMascot
+          makerCount={1}
+          currentView="makers"
+          isVisible
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.tinkerhub-mascot--fallback')).not.toBeNull();
+
+    setTimeoutSpy.mockClear();
+
+    await act(async () => {
+      root.render(
+        <TinkerHubMascot
+          makerCount={2}
+          currentView="makers"
+          isVisible
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.tinkerhub-mascot--fallback')).not.toBeNull();
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+    setTimeoutSpy.mockRestore();
+  });
+});

--- a/src/components/mascot/watchdog.js
+++ b/src/components/mascot/watchdog.js
@@ -1,0 +1,30 @@
+import { getPlayback } from './playback';
+
+export function getMascotAssetUrl(publicBase, assetPath, version) {
+  const separator = assetPath.includes('?') ? '&' : '?';
+  return `${publicBase}${assetPath}${separator}v=${encodeURIComponent(version)}`;
+}
+
+export function getMascotWatchdogFailure({
+  now,
+  pose,
+  poseEndsAt,
+  lastAnimationHeartbeatAt,
+  hasAwakened,
+  schedulerGraceMs,
+  animationGraceMs,
+}) {
+  if (poseEndsAt > 0 && now - poseEndsAt > schedulerGraceMs) {
+    return 'scheduler-timeout';
+  }
+
+  const playback = getPlayback(pose);
+  const isLoopingPose = !Number.isFinite(playback.cycles);
+  const animationDeadline = Math.max(animationGraceMs, pose.cycle * 2 + animationGraceMs);
+
+  if (hasAwakened && isLoopingPose && now - lastAnimationHeartbeatAt > animationDeadline) {
+    return 'animation-stalled';
+  }
+
+  return null;
+}

--- a/src/components/mascot/watchdog.test.js
+++ b/src/components/mascot/watchdog.test.js
@@ -1,0 +1,47 @@
+import {
+  getMascotAssetUrl,
+  getMascotWatchdogFailure,
+} from './watchdog';
+
+describe('mascot watchdog helpers', () => {
+  it('adds a version query to mascot assets', () => {
+    expect(getMascotAssetUrl('', '/images/mascot/dont-look/sprites/sun.webp', 'build 1'))
+      .toBe('/images/mascot/dont-look/sprites/sun.webp?v=build%201');
+  });
+
+  it('reports a stuck scheduler after the pose deadline grace window', () => {
+    expect(getMascotWatchdogFailure({
+      now: 20000,
+      pose: { cycle: 1000 },
+      poseEndsAt: 4000,
+      lastAnimationHeartbeatAt: 19000,
+      hasAwakened: true,
+      schedulerGraceMs: 10000,
+      animationGraceMs: 15000,
+    })).toBe('scheduler-timeout');
+  });
+
+  it('reports a stalled looping animation heartbeat', () => {
+    expect(getMascotWatchdogFailure({
+      now: 40000,
+      pose: { cycle: 4000 },
+      poseEndsAt: 90000,
+      lastAnimationHeartbeatAt: 10000,
+      hasAwakened: true,
+      schedulerGraceMs: 10000,
+      animationGraceMs: 15000,
+    })).toBe('animation-stalled');
+  });
+
+  it('does not require animation heartbeats from finite one-shot poses', () => {
+    expect(getMascotWatchdogFailure({
+      now: 40000,
+      pose: { cycle: 4000, playback: { cycles: 1 } },
+      poseEndsAt: 90000,
+      lastAnimationHeartbeatAt: 10000,
+      hasAwakened: true,
+      schedulerGraceMs: 10000,
+      animationGraceMs: 15000,
+    })).toBeNull();
+  });
+});

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -37,6 +37,19 @@
   transform-origin: bottom right;
 }
 
+.tinkerhub-mascot--fallback {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.tinkerhub-mascot__fallback-sticker {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
 .tinkerhub-mascot__sprite {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## What changed

- Adds a mascot watchdog that detects missed scheduler deadlines and stalled CSS sprite heartbeats.
- Falls back to the original dont-look sticker when a mascot asset fails or the animated runtime becomes unhealthy.
- Adds versioned mascot asset URLs to reduce stale sprite/CSS cache issues on kiosk browsers.
- Adds focused watchdog unit coverage.

## Why

The TV display intermittently freezes the animated mascot. Since the issue is not fully deterministic, this keeps the main display alive and prevents the mascot from staying stuck in a half-animated pose.

## Validation

- CI=true pnpm test --watchAll=false --runInBand src/components/mascot/watchdog.test.js src/components/mascot/policy.test.js src/components/mascot/playback.test.js
- pnpm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mascot reliability by detecting stalled animations and asset loading failures.
  * Added a fallback sticker when the mascot cannot load or animate correctly.
  * Improved handling of mascot assets to reduce caching-related display issues.

* **Style**
  * Added layout styling for the full-size fallback mascot sticker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->