### PR TITLE
fix calendar flickering and sync event pagination

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -194,7 +194,7 @@ function App() {
                                 showCalendar ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'
                             }`}
                         >
-                            <CalendarDashboard />
+                            <CalendarDashboard isActive={showCalendar} />
                         </div>
                     </div>
                 </div>

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -15,7 +15,7 @@ import EmptyState from './EmptyState';
  *   className?: string
  * }} props
  */
-const Calendar = ({ events = [], currentDate, className = '' }) => {
+const Calendar = ({ events = [], currentDate, isActive = true, className = '' }) => {
   const displayDate = currentDate || new Date();
 
   return (
@@ -28,6 +28,7 @@ const Calendar = ({ events = [], currentDate, className = '' }) => {
         <CalendarGrid
           currentDate={displayDate}
           events={events}
+          isActive={isActive}
         />
       ) : (
         <EmptyState type="calendar" />

--- a/src/components/calendar/CalendarGrid.jsx
+++ b/src/components/calendar/CalendarGrid.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { getCategoryColors } from './EventBadge';
 import { layoutWeekEvents } from '../../utils/calendar/calendarLayout';
 
@@ -54,61 +54,69 @@ function isSameDay(a, b) {
 }
 
 /**
- * AutoScrollEvents — renders event bars in a grid that auto-scrolls
- * vertically when content overflows the container.
+ * WeekEventGrid — renders event bars for a single week with a stationary
+ * 2-page crossfade when events overflow the available row height.
  */
-const AutoScrollEvents = ({ tracks, weekIdx }) => {
-  const containerRef = useRef(null);
-  const contentRef = useRef(null);
-  const originalRef = useRef(null);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-  const [contentHeight, setContentHeight] = useState(0);
+const WeekEventGrid = ({ tracks, page }) => {
+  // Columns with overflow (trackIdx >= 2)
+  const overflowingCols = useMemo(() => {
+    const cols = new Set();
+    tracks.forEach(event => {
+      if (event.trackIdx >= 2) {
+        for (let c = event.startCol; c < event.startCol + event.span; c++) {
+          cols.add(c);
+        }
+      }
+    });
+    return cols;
+  }, [tracks]);
 
-  const checkOverflow = useCallback(() => {
-    if (containerRef.current && originalRef.current) {
-      const containerH = containerRef.current.clientHeight;
-      const originalH = originalRef.current.scrollHeight;
-      setIsOverflowing(originalH > containerH + 2); // 2px tolerance
-      setContentHeight(originalH);
-    }
-  }, []);
+  const hasMultiplePages = overflowingCols.size > 0;
 
-  useEffect(() => {
-    checkOverflow();
-    const observer = new ResizeObserver(checkOverflow);
-    if (containerRef.current) observer.observe(containerRef.current);
-    return () => observer.disconnect();
-  }, [tracks, checkOverflow]);
+  // Page 0: top 2 tracks
+  const page0Events = useMemo(() => {
+    return tracks.filter(t => t.trackIdx < 2);
+  }, [tracks]);
 
-  const animationName = `weekScroll-${weekIdx}`;
-  // Scroll through original content height, pause, then loop
-  const duration = Math.max(contentHeight / 12, 8); // ~12px/sec, minimum 8s
+  // Page 1: overflow tracks in top slots + keep non-overflowing days visible
+  const page1Events = useMemo(() => {
+    if (!hasMultiplePages) return page0Events;
 
-  return (
-    <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden relative">
-      {isOverflowing && (
-        <style>{`
-          @keyframes ${animationName} {
-            0% { transform: translateY(0); }
-            45% { transform: translateY(-${contentHeight}px); }
-            50% { transform: translateY(-${contentHeight}px); }
-            95% { transform: translateY(0); }
-            100% { transform: translateY(0); }
+    const events = [];
+    tracks.forEach(event => {
+      if (event.trackIdx >= 2) {
+        events.push({
+          ...event,
+          displayRow: event.trackIdx - 2 + 1,
+        });
+      } else {
+        let overlapsWithOverflow = false;
+        for (let c = event.startCol; c < event.startCol + event.span; c++) {
+          if (overflowingCols.has(c)) {
+            overlapsWithOverflow = true;
+            break;
           }
-        `}</style>
-      )}
-      <div
-        ref={contentRef}
-        style={isOverflowing ? {
-          animation: `${animationName} ${duration}s ease-in-out infinite`,
-        } : undefined}
-      >
-        <div ref={originalRef} className="grid grid-cols-7 auto-rows-max gap-y-1 py-0.5">
-          {tracks.map((event, idx) => {
+        }
+        if (!overlapsWithOverflow) {
+          events.push({
+            ...event,
+            displayRow: event.trackIdx + 1,
+          });
+        }
+      }
+    });
+    return events;
+  }, [tracks, hasMultiplePages, overflowingCols, page0Events]);
+
+  if (!hasMultiplePages) {
+    return (
+      <div className="flex-1 min-h-0 overflow-hidden relative">
+        <div className="grid grid-cols-7 auto-rows-max gap-y-1 py-0.5">
+          {page0Events.map((event, idx) => {
             const colors = getCategoryColors(event.category);
             return (
               <div
-                key={`event-${event.id}-${idx}`}
+                key={`single-${event.id || idx}`}
                 style={{ gridColumn: `${event.startCol} / span ${event.span}`, gridRow: event.trackIdx + 1 }}
                 className="px-1 z-10"
               >
@@ -119,35 +127,84 @@ const AutoScrollEvents = ({ tracks, weekIdx }) => {
             );
           })}
         </div>
-        {/* Duplicate for seamless loop */}
-        {isOverflowing && (
-          <div className="grid grid-cols-7 auto-rows-max gap-y-1 py-0.5 mt-1">
-            {tracks.map((event, idx) => {
-              const colors = getCategoryColors(event.category);
-              return (
-                <div
-                  key={`event-dup-${event.id}-${idx}`}
-                  style={{ gridColumn: `${event.startCol} / span ${event.span}`, gridRow: event.trackIdx + 1 }}
-                  className="px-1 z-10"
-                >
-                  <div className={`truncate text-xs font-semibold tracking-wide leading-snug px-2 py-1 rounded-sm ${colors.badge}`}>
-                    {event.title}
-                  </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 min-h-0 overflow-hidden relative">
+      {/* Page 0 Layer (0s - 5s) */}
+      <div
+        className={`absolute inset-0 transition-opacity duration-500 ease-in-out ${
+          page === 0 ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'
+        }`}
+      >
+        <div className="grid grid-cols-7 auto-rows-max gap-y-1 py-0.5">
+          {page0Events.map((event, idx) => {
+            const colors = getCategoryColors(event.category);
+            return (
+              <div
+                key={`p0-${event.id || idx}`}
+                style={{ gridColumn: `${event.startCol} / span ${event.span}`, gridRow: event.trackIdx + 1 }}
+                className="px-1 z-10"
+              >
+                <div className={`truncate text-xs font-semibold tracking-wide leading-snug px-2 py-1 rounded-sm ${colors.badge}`}>
+                  {event.title}
                 </div>
-              );
-            })}
-          </div>
-        )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Page 1 Layer (5s - 10s) */}
+      <div
+        className={`absolute inset-0 transition-opacity duration-500 ease-in-out ${
+          page === 1 ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'
+        }`}
+      >
+        <div className="grid grid-cols-7 auto-rows-max gap-y-1 py-0.5">
+          {page1Events.map((event, idx) => {
+            const colors = getCategoryColors(event.category);
+            return (
+              <div
+                key={`p1-${event.id || idx}`}
+                style={{ gridColumn: `${event.startCol} / span ${event.span}`, gridRow: event.displayRow }}
+                className="px-1 z-10"
+              >
+                <div className={`truncate text-xs font-semibold tracking-wide leading-snug px-2 py-1 rounded-sm ${colors.badge}`}>
+                  {event.title}
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
 };
 
 
-const CalendarGrid = ({ currentDate, events = [], className = '' }) => {
+const CalendarGrid = ({ currentDate, events = [], isActive = true, className = '' }) => {
   const today = new Date();
   const cells = generateMonthGrid(currentDate);
-  
+  const [page, setPage] = useState(0);
+
+  // Synchronize 5-second page cycle when calendar is active
+  useEffect(() => {
+    if (!isActive) {
+      setPage(0);
+      return;
+    }
+
+    setPage(0);
+    const interval = setInterval(() => {
+      setPage(p => (p === 0 ? 1 : 0));
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [isActive]);
+
   // Group cells into weeks
   const weeks = [];
   for (let i = 0; i < cells.length; i += 7) {
@@ -202,8 +259,8 @@ const CalendarGrid = ({ currentDate, events = [], className = '' }) => {
                 ))}
               </div>
 
-              {/* Event bars — auto-scrolls when overflowing */}
-              <AutoScrollEvents tracks={tracks} weekIdx={weekIdx} />
+              {/* Event bars — synchronized stationary crossfade */}
+              <WeekEventGrid tracks={tracks} page={page} />
             </div>
           );
         })}

--- a/src/components/calendar/UpcomingEvents.jsx
+++ b/src/components/calendar/UpcomingEvents.jsx
@@ -34,26 +34,42 @@ const MarqueeText = ({ text, className }) => {
  *
  * @param {{ events: Array, className?: string }} props
  */
-const UpcomingEvents = ({ events = [], className = '' }) => {
+const UpcomingEvents = ({ events = [], isActive = true, className = '' }) => {
   const [page, setPage] = useState(0);
   const eventsPerPage = 5;
   const totalPages = Math.ceil(events.length / eventsPerPage) || 1;
+  const isFirstMountRef = useRef(true);
+  const wasActiveRef = useRef(false);
 
-  // Reset page when events change
+  // Progressive pagination across calendar visits
   useEffect(() => {
-    setPage(0);
-  }, [events.length]);
+    if (isActive) {
+      if (isFirstMountRef.current) {
+        isFirstMountRef.current = false;
+        setPage(0);
+      } else if (!wasActiveRef.current) {
+        if (totalPages > 2) {
+          setPage(p => (p + 1) % totalPages);
+        } else {
+          setPage(0);
+        }
+      }
+      wasActiveRef.current = true;
+    } else {
+      wasActiveRef.current = false;
+    }
+  }, [isActive, totalPages]);
 
+  // Flip page at 5-second mark during active calendar view
   useEffect(() => {
-    if (totalPages <= 1) return;
+    if (!isActive || totalPages <= 1) return;
+
     const interval = setInterval(() => {
       setPage(p => (p + 1) % totalPages);
-    }, 10000); // 10 seconds per page
-    return () => clearInterval(interval);
-  }, [totalPages]);
+    }, 5000);
 
-  const start = page * eventsPerPage;
-  const display = events.slice(start, start + eventsPerPage);
+    return () => clearInterval(interval);
+  }, [isActive, totalPages]);
 
   if (events.length === 0) {
     return (
@@ -77,7 +93,7 @@ const UpcomingEvents = ({ events = [], className = '' }) => {
       `}</style>
       
       {/* Section label and Page indicator */}
-      <div className="px-4 pt-4 pb-2 flex justify-between items-center">
+      <div className="px-4 pt-4 pb-2 flex justify-between items-center z-20 relative">
         <h4 className="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-gray-500 transition-colors duration-500">
           Upcoming
         </h4>
@@ -95,53 +111,67 @@ const UpcomingEvents = ({ events = [], className = '' }) => {
         )}
       </div>
 
-      {/* Event list */}
-      <div className="flex flex-col flex-1">
-        {display.map((event, idx) => {
-          const startDate = new Date(event.starts_at);
-          const month = startDate.toLocaleString('default', { month: 'short' }).toUpperCase();
-          const day = startDate.getDate();
-          const time = startDate.toLocaleTimeString('en-US', {
-            hour: 'numeric',
-            minute: '2-digit',
-            hour12: true,
-          });
+      {/* Paginated Event List with Smooth Crossfade */}
+      <div className="flex-1 relative min-h-0">
+        {Array.from({ length: totalPages }).map((_, pageIdx) => {
+          const pageSlice = events.slice(pageIdx * eventsPerPage, (pageIdx + 1) * eventsPerPage);
+          const isCurrentPage = page === pageIdx;
 
           return (
             <div
-              key={event.id || idx}
-              className={`flex items-center gap-3 px-4 py-3 transition-colors duration-300 ${
-                idx < display.length - 1
-                  ? 'border-b border-gray-200/30 dark:border-white/5'
-                  : ''
+              key={pageIdx}
+              className={`absolute inset-0 flex flex-col transition-opacity duration-500 ease-in-out ${
+                isCurrentPage ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'
               }`}
             >
-              {/* Date block */}
-              <div className="flex flex-col items-center justify-center w-10 flex-shrink-0">
-                <span className="text-[9px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider leading-none transition-colors duration-500">
-                  {month}
-                </span>
-                <span className="text-lg font-bold text-gray-800 dark:text-gray-100 leading-tight transition-colors duration-500">
-                  {day}
-                </span>
-              </div>
+              {pageSlice.map((event, idx) => {
+                const startDate = new Date(event.starts_at);
+                const month = startDate.toLocaleString('default', { month: 'short' }).toUpperCase();
+                const day = startDate.getDate();
+                const time = startDate.toLocaleTimeString('en-US', {
+                  hour: 'numeric',
+                  minute: '2-digit',
+                  hour12: true,
+                });
 
-              {/* Divider */}
-              <div className="w-px h-8 bg-gray-200/50 dark:bg-gray-600/30 flex-shrink-0 transition-colors duration-500" />
+                return (
+                  <div
+                    key={event.id || idx}
+                    className={`flex items-center gap-3 px-4 py-3 transition-colors duration-300 ${
+                      idx < pageSlice.length - 1
+                        ? 'border-b border-gray-200/30 dark:border-white/5'
+                        : ''
+                    }`}
+                  >
+                    {/* Date block */}
+                    <div className="flex flex-col items-center justify-center w-10 flex-shrink-0">
+                      <span className="text-[9px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider leading-none transition-colors duration-500">
+                        {month}
+                      </span>
+                      <span className="text-lg font-bold text-gray-800 dark:text-gray-100 leading-tight transition-colors duration-500">
+                        {day}
+                      </span>
+                    </div>
 
-              {/* Event info */}
-              <div className="flex-1 min-w-0 flex flex-col justify-center">
-                <MarqueeText 
-                  text={event.title} 
-                  className="text-sm font-semibold text-gray-800 dark:text-gray-100 leading-snug transition-colors duration-500" 
-                />
-                <div className="flex items-center gap-2 mt-0.5">
-                  <span className="text-[11px] text-gray-400 dark:text-gray-500 transition-colors duration-500 flex-shrink-0">
-                    {time}
-                  </span>
-                  <EventBadge category={event.category} />
-                </div>
-              </div>
+                    {/* Divider */}
+                    <div className="w-px h-8 bg-gray-200/50 dark:bg-gray-600/30 flex-shrink-0 transition-colors duration-500" />
+
+                    {/* Event info */}
+                    <div className="flex-1 min-w-0 flex flex-col justify-center">
+                      <MarqueeText 
+                        text={event.title} 
+                        className="text-sm font-semibold text-gray-800 dark:text-gray-100 leading-snug transition-colors duration-500" 
+                      />
+                      <div className="flex items-center gap-2 mt-0.5">
+                        <span className="text-[11px] text-gray-400 dark:text-gray-500 transition-colors duration-500 flex-shrink-0">
+                          {time}
+                        </span>
+                        <EventBadge category={event.category} />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           );
         })}

--- a/src/components/layout/CalendarDashboard.jsx
+++ b/src/components/layout/CalendarDashboard.jsx
@@ -18,7 +18,7 @@ import { Calendar, LiveEventCard, UpcomingEvents } from '../calendar';
 
 const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
-const CalendarDashboard = () => {
+const CalendarDashboard = ({ isActive = true }) => {
   // ── State ──────────────────────────────────────────────────────
   const [data, setData] = useState(null);            // null = never loaded
   const [isInitialLoad, setIsInitialLoad] = useState(true);
@@ -110,6 +110,7 @@ const CalendarDashboard = () => {
         <Calendar
           events={calendarEvents}
           currentDate={currentDate}
+          isActive={isActive}
           className="h-full"
         />
       </div>
@@ -122,6 +123,7 @@ const CalendarDashboard = () => {
         {/* Upcoming Events */}
         <UpcomingEvents
           events={upcomingEvents}
+          isActive={isActive}
           className="flex-1 overflow-hidden"
         />
       </div>


### PR DESCRIPTION
- Replaced jittery auto-scrolling with a stationary 5s 2-page crossfade for days with overflow events (3+ events).
- Added progressive pagination to Upcoming Events so all pages (1–4) rotate across display cycles instead of resetting to page 1 every visit.
- Wired `isActive` prop through `CalendarDashboard` to pause and resume pagination timers when switching between Makers and Calendar views.